### PR TITLE
Fix: Handle date conversion in settingsStore correctly

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -90,8 +90,8 @@ const convertSettingsToFirestore = (settings: SiteSettings) => {
 
 // Convertir documento de Firestore a configuración
 const convertFirestoreToSettings = (data: any): SiteSettings => {
-  if (data.terms?.createdAt) {
-    data.terms.createdAt = data.terms.createdAt?.toDate?.()?.toISOString() || data.terms.createdAt;
+  if (data.terms?.createdAt && typeof data.terms.createdAt.toDate === 'function') {
+    data.terms.createdAt = data.terms.createdAt.toDate().toISOString();
   }
   
   return data;


### PR DESCRIPTION
Modified `convertFirestoreToSettings` to check if `createdAt` is a Firebase Timestamp object before calling `toDate().toISOString()`. This prevents an error when `createdAt` is already an ISO string.